### PR TITLE
build: correctly bump version in package-lock.json file

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,5 +1,12 @@
 {
-  "bumpFiles": ["packages/npm/package.json", "package.json"],
+  "bumpFiles": [
+    "packages/npm/package.json",
+    "package.json",
+    {
+      "filename": "package-lock.json",
+      "updater": "scripts/bump-package-lock.cjs"
+    }
+  ],
   "scripts": {
     "postchangelog": "prettier CHANGELOG.md -w"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onfido/castor-tokens",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onfido/castor-tokens",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -14312,7 +14312,7 @@
     },
     "packages/npm": {
       "name": "@onfido/castor-tokens",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "Apache-2.0"
     }
   },

--- a/scripts/bump-package-lock.cjs
+++ b/scripts/bump-package-lock.cjs
@@ -1,0 +1,20 @@
+// can't be `bump-package-lock.ts` as it is invoked by `standard-version` as a
+// custom updater
+
+const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+
+module.exports.readVersion = function (contents) {
+  return JSON.parse(contents).packages[''].version;
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const json = JSON.parse(contents);
+  const indent = detectIndent(contents).indent;
+  const newline = detectNewline(contents);
+  json.version = version;
+  json.packages[''].version = version;
+  json.packages['packages/npm'].version = version;
+  return stringifyPackage(json, indent, newline);
+};


### PR DESCRIPTION
## Purpose

npm workspace bersion bump in `package-lock.json` requires version to be bumped in 3 places.

## Approach

Bumping cannot be done by just specifying a file, instead a custom bumper has to be used, same as on https://github.com/onfido/castor/pull/234.

## Testing

`npm run release -- --dry-run`

## Risks

N/A
