### PR TITLE
build: lint ts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Run ESLint
         run: npm run lint:es
 
+      - name: Run tsc (type check)
+        run: npm run lint:ts
+
       - name: Run Prettier
         run: npm run lint:prettier

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "concurrently npm:lint:*",
     "lint:commit": "commitlint --from origin/main --to HEAD --verbose",
     "lint:es": "eslint . --ignore-path .gitignore --max-warnings 0",
+    "lint:ts": "tsc --noEmit",
     "lint:style": "stylelint '**/*.{,s}css' --ignore-path .gitignore --max-warnings 0",
     "lint:prettier": "prettier . --check --ignore-unknown",
     "test": "jest --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["**/*"],
-  "exclude": ["node_modules/**/*"],
+  "exclude": ["node_modules/**/*", "packages/npm/src/index.ts"],
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": false,


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/718, catch TS (type) errors ahead of time.

## Approach

Run `tsc --noEmit` on lint.

## Testing

Locally, on CI.

## Risks

Had to ignore main `index.ts` of a source, because it fails on linting generated files (that are not generated if package is not built).
