### PR TITLE
build: automatically sort imports

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,5 @@ packages/npm/src/tokens.scss
 packages/npm/src/theme-*.scss
 
 # Distribution files
+coverage
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "lint-staged": "^11.0.0",
         "lodash": "^4.17.21",
         "prettier": "^2.3.0",
+        "prettier-plugin-organize-imports": "^2.1.0",
         "sass": "^1.34.0",
         "shx": "^0.3.3",
         "standard-version": "^9.0.0",
@@ -11183,6 +11184,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.1.0.tgz",
+      "integrity": "sha512-P6TzXkuZRV4g9Fl363tN+r6/ecynu0fwmItKCb/04iksrUtwl/6Jf4DxBPuW8UbcgFRadltxB0VlV5Yh1Ec0Ow==",
+      "dev": true,
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9"
       }
     },
     "node_modules/pretty-format": {
@@ -23389,6 +23400,13 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
       "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true
+    },
+    "prettier-plugin-organize-imports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.1.0.tgz",
+      "integrity": "sha512-P6TzXkuZRV4g9Fl363tN+r6/ecynu0fwmItKCb/04iksrUtwl/6Jf4DxBPuW8UbcgFRadltxB0VlV5Yh1Ec0Ow==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-format": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lint-staged": "^11.0.0",
     "lodash": "^4.17.21",
     "prettier": "^2.3.0",
+    "prettier-plugin-organize-imports": "^2.1.0",
     "sass": "^1.34.0",
     "shx": "^0.3.3",
     "standard-version": "^9.0.0",

--- a/packages/npm/src/index.ts
+++ b/packages/npm/src/index.ts
@@ -1,3 +1,5 @@
+// tslint:disable:ordered-imports
+
 export * from './utils';
 
 // Theo generated files


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/202, sorting imports automatically.

## Approach

Sort with Prettier using `prettier-plugin-organize-imports`.

## Testing

N/A

## Risks

N/A
