### PR TITLE
ci: setup node version based on .nvmrc file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,14 @@ jobs:
         uses: actions/checkout@v2.3.4
       - run: git fetch origin main # needed for commitlint
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install Node dependencies
         run: npm ci --no-audit --no-optional

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,14 @@ jobs:
       - name: Checkout Git repository
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install Node dependencies
         run: npm ci --no-audit --no-optional

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,14 @@ jobs:
       - name: Checkout Git repository
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Node
-        uses: actions/setup-node@v2.1.4
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
+        uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install Node dependencies
         run: npm ci --no-audit --no-optional


### PR DESCRIPTION
## Purpose

When upgrading Node version, we need to change it in multiple places. However, as we do use `.nvmrc` config, better to use such on CI also.

## Approach

On CI, read Node version required from `.nvmrc` file, then use that when setting up Node.

## Testing

On CI pipeline, inspecting what Node version was used.

## Risks

N/A
