### PR TITLE
docs: remove duplicate "changelog" heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,4 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## 1.0.0-beta.1 (2021-05-07)
 
-# Changelog
-
 Initial release.


### PR DESCRIPTION
## Purpose

Heading `Changelog` should only be set once in the document.

## Approach

Remove 2nd `Changelog` heading.

## Testing

On https://github.com/onfido/castor-tokens/blob/docs/changelog/CHANGELOG.md

## Risks

N/A
