### PR TITLE
ci: publish android library (on gh release, as asset)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - release/*
 
 jobs:
-  publish:
+  npm:
     name: Publish npm package
     runs-on: ubuntu-latest
 
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --no-audit --no-optional
 
-      - name: Build npm package
+      - name: Build package
         run: npm run build:npm
 
       - name: Publish to npm
@@ -34,3 +34,42 @@ jobs:
         with:
           package: ./packages/npm/package.json
           token: ${{ secrets.NPM_TOKEN }}
+
+  android:
+    name: Publish Android library
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v2.3.4
+
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
+
+      - name: Install Node dependencies
+        run: npm ci --no-audit --no-optional
+
+      - name: Setup OpenJDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Build library
+        run: npm run build:android
+
+      - name: Make GitHub release, publish asset
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            libraries/android/castor-tokens/build/outputs/aar/castor-tokens-debug.aar
+            libraries/android/castor-tokens/build/outputs/aar/castor-tokens-release.aar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose

For beta Android release, we're only publishing a built asset on GitHub.

## Approach

Use [action gh-release](https://github.com/softprops/action-gh-release) to make a new release when tagging, also attaching both debug and release AAR files.

## Testing

Tested as PoC: https://github.com/josokinas/upload-release-asset-poc/releases

Actions:
- when tag was not created: https://github.com/josokinas/upload-release-asset-poc/runs/2764536301?check_suite_focus=true
- when tag was created: https://github.com/josokinas/upload-release-asset-poc/runs/2764539734?check_suite_focus=true

Test image file available as an asset on `v0.1` release.

## Risks

N/A
