### PR TITLE
feat: add progress (content, background) colors

### DIFF
--- a/src/themes/day.json
+++ b/src/themes/day.json
@@ -121,6 +121,15 @@
     {
       "type": "color",
       "category": "color",
+      "name": "content-progress",
+      "value": "{!color-primary-500}",
+      "meta": {
+        "opacity": 1
+      }
+    },
+    {
+      "type": "color",
+      "category": "color",
       "name": "content-logo",
       "value": "{!color-primary-500}",
       "meta": {
@@ -384,6 +393,15 @@
       "category": "color",
       "name": "background-spinner",
       "value": "{!color-neutral-700}",
+      "meta": {
+        "opacity": 0.15
+      }
+    },
+    {
+      "type": "color",
+      "category": "color",
+      "name": "background-progress",
+      "value": "{!color-primary-500}",
       "meta": {
         "opacity": 0.15
       }

--- a/src/themes/night.json
+++ b/src/themes/night.json
@@ -121,6 +121,15 @@
     {
       "type": "color",
       "category": "color",
+      "name": "content-progress",
+      "value": "{!color-primary-muted-300}",
+      "meta": {
+        "opacity": 1
+      }
+    },
+    {
+      "type": "color",
+      "category": "color",
       "name": "content-logo",
       "value": "{!color-neutral-white}",
       "meta": {
@@ -384,6 +393,15 @@
       "category": "color",
       "name": "background-spinner",
       "value": "{!color-neutral-400}",
+      "meta": {
+        "opacity": 0.15
+      }
+    },
+    {
+      "type": "color",
+      "category": "color",
+      "name": "background-progress",
+      "value": "{!color-primary-muted-300}",
       "meta": {
         "opacity": 0.15
       }


### PR DESCRIPTION
## Purpose

Add content & background colors for "progress" (will be used in Progress component).

## Approach

Add `color-content-progress` and `color-background-progress` on both night and day themes.

## Testing

Build tested locally.

## Risks

N/A
