### PR TITLE
build: correct linking to examples

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -36,9 +36,9 @@
     </div>
     <nav class="container">
       <ul>
-        <li><a href="/tokens.html">Base tokens</a></li>
-        <li><a href="/themes/day.html">Day theme tokens</a></li>
-        <li><a href="/themes/night.html">Night theme tokens</a></li>
+        <li><a href="tokens.html">Base tokens</a></li>
+        <li><a href="themes/day.html">Day theme tokens</a></li>
+        <li><a href="themes/night.html">Night theme tokens</a></li>
       </ul>
     </nav>
     <div class="container">


### PR DESCRIPTION
## Purpose

Because GitHub Pages deploys to a subdirectory, we need linking to examples be of a relative files.

## Approach

Change linking to base and theme token example.

## Testing

Once merged to `main`.

## Risks

N/A
