### PR TITLE
feat(android): exclude base tokens from "night" mode values

### DIFF
--- a/src/values/color-night.json
+++ b/src/values/color-night.json
@@ -1,3 +1,3 @@
 {
-  "imports": ["../tokens.json", "../themes/night.json"]
+  "imports": ["../themes/night.json"]
 }


### PR DESCRIPTION
## Purpose

Exclude base tokens from "night" mode values.

This is because on "night" mode all regular values are inherited.

## Approach

When generating values for "night" mode, do not include base tokens.

## Testing

Tested on an Android app.

## Risks

N/A
