### PR TITLE
chore: run commitizen via npx

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -6,5 +6,5 @@ COMMIT_SOURCE=$2 # <none> (git commit) | message (git commit -m <msg>) | templat
 # SHA1=$3
 
 if [ "$COMMIT_SOURCE" = "" ]; then
-  exec < /dev/tty && yarn cz --hook || true
+  exec < /dev/tty && npx cz --hook || true
 fi


### PR DESCRIPTION
## Purpose

Husky should run Commitizen via npx (not via Yarn).

## Approach

Use npx to run Commitizen command.

## Testing

Tested locally.

## Risks

N/A
