### PR TITLE
build: optimising sideEffect to exclude CSS from tree shaking

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -5,7 +5,9 @@
   "author": "Onfido",
   "license": "Apache-2.0",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/onfido/castor-tokens.git",


### PR DESCRIPTION
## Purpose

CSS can't be sideEffect free as it does not have an export. 
This is because Gatsby (and probably webpack) will tree-shake import '@onfido/castor-tokens/dist/day.css' (or '@onfido/castor-tokens/dist/night.css');
[gatsbyjs/gatsby#19446](https://github.com/gatsbyjs/gatsby/issues/19446)
It improves the lives of Gatsby/webpack users.

## Approach

Excluding it from tree shaking.

## Testing

N/A

## Risks

The side-effect is introduced by the bundler when it decides that a CSS import requires a DOM element to be created, not the import itself.
